### PR TITLE
Don't override the registered transformers

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,6 +3,5 @@
 // Register "schema:" namespace
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['schema'][] = 'GeorgRinger\\SchemaOrgGenerator\\ViewHelpers';
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['schema-org']['transformators'] = [
-  \GeorgRinger\SchemaOrgGenerator\Transformator\TtAddressTransformator::class,
-];
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['schema-org']['transformators'][] =
+    \GeorgRinger\SchemaOrgGenerator\Transformator\TtAddressTransformator::class;


### PR DESCRIPTION
I'm unable to register my custom transformer because it's overridden right away.